### PR TITLE
speeding things up

### DIFF
--- a/write3mf.m
+++ b/write3mf.m
@@ -176,7 +176,7 @@ function writeTempFiles(files)
 function write3DModel(files , vertices , faces, colors)
 % Writes the 3D model proper
 
-    fid = fopen(files.model , 'w');
+    fid = fopen(files.model , 'W');
     
     % Write header
     fprintf(fid , '<?xml version="1.0" encoding="UTF-8"?>\n');
@@ -192,9 +192,7 @@ function write3DModel(files , vertices , faces, colors)
         unique_colors = rgb2hex(unique_colors);
 
         fprintf(fid , '\t\t<m:colorgroup id="2">\n');
-        for k = 1 : size(unique_colors , 1)
-            fprintf(fid , '\t\t\t<m:color color="#%s" />\n' , unique_colors(k,:));        
-        end
+        fprintf(fid , '\t\t\t<m:color color="#%c%c%c%c%c%c" />\n' , unique_colors');  
         fprintf(fid , '\t\t</m:colorgroup>\n');
     end
 
@@ -205,23 +203,17 @@ function write3DModel(files , vertices , faces, colors)
     
     % Vertices
     fprintf(fid , '\t\t\t\t<vertices>\n');
-    for k = 1 : size(vertices , 1)
-        fprintf(fid , '\t\t\t\t\t<vertex x="%.2f" y="%.2f" z="%.2f" />\n' , vertices(k,:));        
-    end    
+    fprintf(fid , '\t\t\t\t\t<vertex x="%.2f" y="%.2f" z="%.2f" />\n' , vertices');  
     fprintf(fid , '\t\t\t\t</vertices>\n');
     
     % Triangles
     fprintf(fid , '\t\t\t\t<triangles>\n');
     if isempty(colors)
-        for k = 1 : size(faces , 1)
-            fprintf(fid , '\t\t\t\t\t<triangle v1="%u" v2="%u" v3="%u" />\n' , faces(k,:) - 1);        
-        end        
+        fprintf(fid , '\t\t\t\t\t<triangle v1="%u" v2="%u" v3="%u" />\n' , faces' - 1);       
     else
-        for k = 1 : size(faces , 1)
-            row_colors = idx_colors(faces(k,:))' - 1;
-            row_faces = faces(k,:) - 1;
-            fprintf(fid , '\t\t\t\t\t<triangle v1="%u" v2="%u" v3="%u" pid="2" p1="%u" p2="%u" p3="%u" />\n' , row_faces , row_colors);        
-        end        
+        row_colors = idx_colors(faces) - 1;
+        row_faces = faces - 1;
+        fprintf(fid , '\t\t\t\t\t<triangle v1="%u" v2="%u" v3="%u" pid="2" p1="%u" p2="%u" p3="%u" />\n' , [row_faces row_colors]');      
     end
     fprintf(fid , '\t\t\t\t</triangles>\n');
     


### PR DESCRIPTION
Hi Claudio,

Thanks for implementing the Linux-compatible syntax. Whilst I didn't test your version directly, I have made exactly the same changes previously and it worked fine on both Windows and Linux.

I have also introduced some changes to your write code which have helped me to speed things up considerably. As an example, writing an object with 3.3M vertices and 6.5M faces took ~400s with the current code and ~53s after the update. The output file is still loading just fine.

The update simply gets rid of the for loops as they tend to slow things down. Also, the target file is opened with a capital W permission - [see this thread](https://uk.mathworks.com/matlabcentral/answers/83870-fastest-way-to-write-data-to-a-text-file-fprintf).

Hope this helps. Best wishes